### PR TITLE
添加单例模式（继承自MonoBehaviour和非继承自MonoBehaviour）模块，共享MonoBehaviour模块以及管理器基类…

### DIFF
--- a/Assets/Plugins/Purpaca/runtime/src/ManagerBase.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/ManagerBase.cs
@@ -1,0 +1,32 @@
+using Purpaca.Singleton;
+
+namespace Purpaca
+{
+    /// <summary>
+    /// 管理器基类
+    /// </summary>
+    public abstract class ManagerBase<T> : Singleton<T> where T : ManagerBase<T>
+    {
+        /// <summary>
+        /// 初始化管理器
+        /// </summary>
+        public static void Init()
+        {
+            _ = instance;
+        }
+
+        public static T Instance => instance;
+
+        /// <summary>
+        /// 当管理器被初始化时调用
+        /// </summary>
+        protected virtual void OnInit() { }
+
+        #region Unity 消息
+        protected ManagerBase() : base()
+        {
+            OnInit();
+        }
+        #endregion
+    }
+}

--- a/Assets/Plugins/Purpaca/runtime/src/ManagerBase.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/ManagerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f08d12bc54f40d647933315a6ce79748
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/MonoManagerBase.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/MonoManagerBase.cs
@@ -1,0 +1,32 @@
+using Purpaca.Singleton;
+
+namespace Purpaca
+{
+    /// <summary>
+    /// 基于MonoBehaviour的管理器基类
+    /// </summary>
+    public abstract class MonoManagerBase<T> : AutoInstantiateMonoSingleton<T> where T : MonoManagerBase<T>
+    {
+        /// <summary>
+        /// 初始化管理器
+        /// </summary>
+        public static void Init()
+        {
+            _ = instance;
+        }
+
+        /// <summary>
+        /// 当管理器被初始化时调用，相当于MonoBehaviour.Awake
+        /// </summary>
+        protected virtual void OnInit() { }
+
+        #region Unity 消息
+        protected override void Awake()
+        {
+            base.Awake();
+            DontDestroyOnLoad(instance.gameObject);
+            instance.OnInit();
+        }
+        #endregion
+    }
+}

--- a/Assets/Plugins/Purpaca/runtime/src/MonoManagerBase.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/MonoManagerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a8e3c1f8d560414fbf1b96ee5207d9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/SharedMonoBehaviour.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/SharedMonoBehaviour.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.Events;
+using IEnumerator = System.Collections.IEnumerator;
+
+namespace Purpaca
+{
+    /// <summary>
+    /// 共享的MonoBehaviour，为非继承自MonoBehaviour的类型提供使用MonoBehaviour的生命周期方法以及协程的功能
+    /// </summary>
+    public sealed class SharedMonoBehaviour : MonoManagerBase<SharedMonoBehaviour>
+    {
+        #region 字段
+        private event UnityAction m_onUpdate;
+        private event UnityAction m_onFixedUpdate;
+        private event UnityAction m_onLateUpdate;
+        #endregion
+
+        #region 事件
+
+        #region MonoBehaviour 生命周期方法相关事件
+        public static event UnityAction OnUpdate
+        {
+            add => instance.m_onUpdate += value;
+            remove => instance.m_onUpdate -= value;
+        }
+
+        public static event UnityAction OnFixedUpdate
+        {
+            add => instance.m_onFixedUpdate += value;
+            remove => instance.m_onFixedUpdate -= value;
+        }
+
+        public static event UnityAction OnLateUpdate
+        {
+            add => instance.m_onLateUpdate += value;
+            remove => instance.m_onLateUpdate -= value;
+        }
+        #endregion
+
+        #endregion
+
+        #region Public 方法
+        /// <summary>
+        /// 启动协程
+        /// </summary>
+        public static Coroutine LaunchCoroutine(IEnumerator routine)
+        {
+            return instance.StartCoroutine(routine);
+        }
+
+        /// <summary>
+        /// 终止当前共享MonoBehaviour上的指定协程
+        /// </summary>
+        public static void EndCoroutine(Coroutine routine)
+        {
+            instance.StopCoroutine(routine);
+        }
+
+        /// <summary>
+        /// 终止当前共享MonoBehaviour上正在运行的全部协程
+        /// </summary>
+        public static void EndAllCoroutine()
+        {
+            instance.StopAllCoroutines();
+        }
+        #endregion
+
+        #region Unity 消息
+        private void Update()
+        {
+            m_onUpdate?.Invoke();
+        }
+
+        private void FixedUpdate()
+        {
+            m_onFixedUpdate?.Invoke();
+        }
+
+        private void LateUpdate()
+        {
+            m_onLateUpdate?.Invoke();
+        }
+        #endregion
+    }
+}

--- a/Assets/Plugins/Purpaca/runtime/src/SharedMonoBehaviour.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/SharedMonoBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 060c839faaa997c4dbc7d85a4abb9f23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abfd098dea4876c4e943ee8ba771c6d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/AutoInstantiateMonoSingleton.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/AutoInstantiateMonoSingleton.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace Purpaca.Singleton
+{
+    /// <summary>
+    /// 在被访问时会自动实例化的单例MonoBehaviour基类
+    /// </summary>
+    public abstract class AutoInstantiateMonoSingleton<T> : MonoBehaviour where T : AutoInstantiateMonoSingleton<T>
+    {
+        private static T m_instance;
+
+        protected static T instance
+        {
+            get
+            {
+                if (m_instance == null)
+                {
+                    GameObject gameObject = new GameObject(typeof(T).Name);
+                    m_instance = gameObject.AddComponent<T>();
+                }
+
+                return m_instance;
+            }
+        }
+
+        #region Unity 消息
+        protected virtual void Awake()
+        {
+            if (m_instance != null && !ReferenceEquals(m_instance, this))
+            {
+                Debug.LogError($"Component \"{typeof(T).FullName}\" on gameobject \"{gameObject.name}\" is designed as a singleton script component, and the unique instance already exists. This instance would be destroyed.");
+                Destroy(this);
+                return;
+            }
+
+            m_instance = (T)this;
+        }
+        #endregion
+    }
+}

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/AutoInstantiateMonoSingleton.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/AutoInstantiateMonoSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a56a623d3d11474781c79d8e41963ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/MonoSingleton.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/MonoSingleton.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace Purpaca.Singleton
+{
+    /// <summary>
+    /// 只能存在一个实例对象的单例MonoBehaviour基类
+    /// </summary>
+    public abstract class MonoSingleton<T> : MonoBehaviour where T : MonoSingleton<T> 
+    {
+        private static T m_instance;
+
+        #region 属性
+        protected static T instance { get => m_instance; }
+        #endregion
+
+        #region Public 方法
+        /// <summary>
+        /// 获取此类型的单例实例
+        /// </summary>
+        /// <param name="includeInactive">是否允许获取处于未激活状态的实例</param>
+        public static T GetInstance(bool includeInactive = false) 
+        {
+            if (m_instance == null)
+            {
+                m_instance = FindObjectOfType<T>(includeInactive);
+            }
+
+            return m_instance;
+        }
+        #endregion
+
+        #region Unity 消息
+        protected virtual void Awake()
+        {
+            if (m_instance != null)
+            {
+                Debug.LogError($"Component \"{typeof(T).FullName}\" on gameobject \"{gameObject.name}\" is designed as a singleton script component, and the unique instance already exists. This instance would be destroyed.");
+                Destroy(this);
+                return;
+            }
+
+            m_instance = (T)this;
+        }
+        #endregion
+    }
+}

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/MonoSingleton.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/MonoSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3f3862f793678848a73d2a2cee83169
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/Singleton.cs
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/Singleton.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Purpaca.Singleton
+{
+    /// <summary>
+    /// 单例模式基类
+    /// </summary>
+    public abstract class Singleton<T> where T : Singleton<T>
+    {
+        private static volatile T m_instance;
+        private static bool initialized => m_instance != null;
+        private static object locker = new object();
+
+        #region 构造器
+        protected Singleton()
+        {
+            if (initialized)
+            {
+                throw new InvalidOperationException($"\"{typeof(T).FullName}\" is a singleton type and the unique instance already exists. Unable to create another instance of this type");
+            }
+
+            m_instance = this as T;
+        }
+        #endregion
+
+        #region 属性
+        protected static T instance
+        {
+            get
+            {
+                if (m_instance == null)
+                {
+                    lock (locker)
+                    {
+                        if (m_instance == null)
+                        {
+                            m_instance = Activator.CreateInstance(typeof(T), true) as T;
+                        }
+
+                        return m_instance;
+                    }
+                }
+
+                return m_instance;
+            }
+        }
+    }
+    #endregion
+}

--- a/Assets/Plugins/Purpaca/runtime/src/Singleton/Singleton.cs.meta
+++ b/Assets/Plugins/Purpaca/runtime/src/Singleton/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e8f513462994ec42868dc315ad2b800
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Purpaca/third-party/Newtonsoft-Json/~Documentation.meta
+++ b/Assets/Plugins/Purpaca/third-party/Newtonsoft-Json/~Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9399ed89d81770143a592f9bdc75a0b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 新增  
- 单例模式基类  
  - Singleton\<T>：非继承自MonoBehaviour的懒汉式单例模式基类，对线程安全进行了处理
  - MonoSingleton\<T>：继承自MonoBehaviour的单例模式基类，会在被实例化时检查单例唯一性并移除多余的实例
  - AutoInstantiateMonoSingleton\<T>：继承自MonoBehaviour的懒汉式单例模式基类，会在尝试访问其单例实例时自动创建GameObject并挂载脚本
- 共享MonoBehaviour模块：SharedMonoBehaviour类为非继承自MonoBehaviour的类型提供使用Unity生命周期方法和执行协程的能力
- ManagerBase\<T>与MonoManagerBase\<T>基类：为后续的将新增的管理器提供基类方法
  
### 修改  
暂无  

### 修复  
暂无